### PR TITLE
use "currentColor" as default fill prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ class IconBase extends React.Component {
             verticalAlign: "middle",
         };
         var props = {
-            fill: "#000",
+            fill: "currentColor",
             width: this.props.size,
             height: this.props.size
         }


### PR DESCRIPTION
See https://developer.mozilla.org/en/docs/Web/CSS/color_value#currentColor_keyword for details on the `currentColor` keyword. It's basically a better default than `#000` because the icon will now use the `color` of the current context. In other words: the icon will have the same color as the text. Which is what you usually want and what icon fonts give you by default.

Support is basically identical to SVG http://caniuse.com/#feat=currentcolor