### PR TITLE
color convenience prop, improved contextTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 import { default as React, PropTypes } from 'react'
+const defaultColor = '#444'
 const defaultSize = '1em'
 
-const IconBase = ({ children, size, style, ...props }, { reactIconBase }) => {
+const IconBase = ({ children, color, size, style, ...props }, { reactIconBase }) => {
     const computedSize = size ? size : (reactIconBase && reactIconBase.size || defaultSize)
+    const computedColor = color ? color : (reactIconBase && reactIconBase.color || defaultColor)
     const computedStyle = {
-        verticalAlign: "middle",
+        verticalAlign: 'middle',
+        color: computedColor,
         ...(reactIconBase && reactIconBase.style || {}),
         ...style
     }
@@ -24,16 +27,17 @@ const IconBase = ({ children, size, style, ...props }, { reactIconBase }) => {
     )
 }
 
-IconBase.contextTypes = {
-    reactIconBase: PropTypes.object
-}
-
 IconBase.propTypes = {
+    color: PropTypes.string,
     size: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number
     ]),
     style: PropTypes.object
+}
+
+IconBase.contextTypes = {
+    reactIconBase: PropTypes.shape(IconBase.propTypes)
 }
 
 export default IconBase


### PR DESCRIPTION
I noticed that the README instructions I added weeks ago included a color prop... that doesn't actually work. Either merge this or I'll adjust the README to be less confusing.