### PR TITLE
Remove default color prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ npm install react-icon-base --save
 
 ### Usage
 
-```javascript
-
-let React = require('react');
-let IconBase = require('react-icon-base');
+```js
+import { default as React } from 'react'
+import { default as IconBase } from 'react-icon-base'
 
 export default class FaHeart extends React.Component {
     render() {
@@ -22,7 +21,7 @@ export default class FaHeart extends React.Component {
             <IconBase viewBox="0 0 1792 1896.0833" {...this.props}>
                 <g><path d="m896 1664q-26 0-44-18l-624-602q-10-8-27.5-26t-55.5-65.5-68-97.5-53.5-121-23.5-138q0-220 127-344t351-124q62 0 126.5 21.5t120 58 95.5 68.5 76 68q36-36 76-68t95.5-68.5 120-58 126.5-21.5q224 0 351 124t127 344q0 221-229 450l-623 600q-18 18-44 18z"/></g>
             </IconBase>
-        );
+        )
     }
 }
 ```
@@ -30,7 +29,7 @@ export default class FaHeart extends React.Component {
 ### Configuration
 You can configure react-icon-base props in context.
 
-```javascript
+```js
 class Theme extends Component {
 
     static childContextTypes = {
@@ -51,11 +50,10 @@ class Theme extends Component {
 }
 ```
 
-And you can override context props at the instance level.
+Context can be overriden inline, like so:
 
-```javascript
-const MyIcon = () =>
-    <Icon size={30} color='aliceblue' style={{ ... }} />
+```js
+<Icon size={30} color='aliceblue' style={{ ... }} />
 ```
 
 ### Licence

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default class FaHeart extends React.Component {
 You can configure react-icon-base props in context.
 
 ```js
-class Theme extends Component {
+class HigherOrderComponent extends Component {
 
     static childContextTypes = {
         reactIconBase: PropTypes.object
@@ -46,6 +46,10 @@ class Theme extends Component {
                 }
             }
         }
+    }
+
+    render() {
+        ...
     }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,42 +1,37 @@
 import { default as React, PropTypes } from 'react'
-const defaultColor = '#444'
-const defaultSize = '1em'
 
-const IconBase = ({ children, color, size, style, ...props }, { reactIconBase }) => {
-    const computedSize = size ? size : (reactIconBase && reactIconBase.size || defaultSize)
-    const computedColor = color ? color : (reactIconBase && reactIconBase.color || defaultColor)
-    const computedStyle = {
+const IconBase = ({ children, color, size, style, ...props }, { reactIconBase = {} }) => {
+  const computedSize = size || reactIconBase.size || '1em'
+  return (
+    <svg
+      children={children}
+      fill='currentColor'
+      preserveAspectRatio='xMidYMid meet'
+      height={computedSize}
+      width={computedSize}
+      {...reactIconBase}
+      {...props}
+      style={{
         verticalAlign: 'middle',
-        color: computedColor,
-        ...(reactIconBase && reactIconBase.style || {}),
+        color: color || reactIconBase.color,
+        ...(reactIconBase.style || {}),
         ...style
-    }
-    return (
-        <svg
-            fill="currentColor"
-            preserveAspectRatio="xMidYMid meet"
-            height={computedSize}
-            width={computedSize}
-            {...reactIconBase}
-            {...props}
-            style={computedStyle}
-        >
-            {children}
-        </svg>
-    )
+      }}
+    />
+  )
 }
 
 IconBase.propTypes = {
-    color: PropTypes.string,
-    size: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number
-    ]),
-    style: PropTypes.object
+  color: PropTypes.string,
+  size: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  style: PropTypes.object
 }
 
 IconBase.contextTypes = {
-    reactIconBase: PropTypes.shape(IconBase.propTypes)
+  reactIconBase: PropTypes.shape(IconBase.propTypes)
 }
 
 export default IconBase

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "react-icon-base",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "base element for react-icons",
   "main": "lib/index.js",
   "jsnext:main": "index.js",
   "scripts": {
+    "lint": "standard",
     "build": "babel index.js --out-dir lib",
-    "prepublish": "npm run build"
+    "prepublish": "npm test && npm run build",
+    "test": "npm run lint && mocha test --compilers js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -26,17 +28,50 @@
   "devDependencies": {
     "babel": "6.5.2",
     "babel-cli": "6.7.5",
-    "babel-eslint": "^5.0.0-beta6",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "eslint": "^1.8.0",
-    "eslint-config-airbnb": "^0.1.0",
-    "eslint-plugin-react": "^3.6.3"
+    "commitizen": "^2.8.2",
+    "cz-conventional-changelog": "^1.1.6",
+    "expect": "^1.20.2",
+    "ghooks": "^1.3.2",
+    "mocha": "^2.5.3",
+    "react": "^15.2.1",
+    "react-addons-test-utils": "^15.2.1",
+    "standard": "^7.1.2",
+    "validate-commit-msg": "^2.6.1"
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"
+  },
+  "standard": {
+    "globals": [
+      "beforeEach",
+      "describe",
+      "it"
+    ],
+    "parser": "babel-eslint"
+  },
+  "config": {
+    "ghooks": {
+      "commit-msg": "validate-commit-msg"
+    },
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    },
+    "validate-commit-msg": {
+      "types": [
+        "issue",
+        "master",
+        "revert"
+      ],
+      "warnOnFail": false,
+      "maxSubjectLength": 100,
+      "subjectPattern": ".+",
+      "subjectPatternErrorMsg": "subject does not match subject pattern!",
+      "helpMessage": ""
+    }
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,31 @@
+import { default as React } from 'react'
+import { default as TestUtils } from 'react-addons-test-utils'
+import { default as expect } from 'expect'
+import { default as IconBase } from '..'
+
+const renderer = TestUtils.createRenderer()
+
+describe('IconBase', () => {
+  let outer
+
+  beforeEach(() => {
+    renderer.render(<IconBase />)
+    outer = renderer.getRenderOutput()
+  })
+
+  it('renders svg', () => {
+    expect(outer.type).toEqual('svg')
+  })
+
+  it('has default props', () => {
+    expect(outer.props.fill).toEqual('currentColor')
+    expect(outer.props.preserveAspectRatio).toEqual('xMidYMid meet')
+    expect(outer.props.height).toEqual('1em')
+    expect(outer.props.width).toEqual('1em')
+    expect(outer.props.style.verticalAlign).toEqual('middle')
+  })
+
+  it('has does not have a default color', () => {
+    expect(outer.props.style.color).toNotExist()
+  })
+})


### PR DESCRIPTION
@gorangajic 

There are a few extras here:

- Unit tests
- Standard linting
- Commit message validation
 - issue(issue-number): message
 - master(issue-number): message
 - revert(issue-number): message
 - highly configurable in `package.json` if you don't like that set up.


I'd like to get this connected to travis ci so we can monitor build status and run unit tests before merging. Add me as a contributor and I'd be happy to set that up.

