### PR TITLE
Move PropTypes to separate package for React Version ^15.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import { default as React, PropTypes } from 'react'
-
+import { default as React } from 'react'
+import { PropTypes } from 'prop-types'
 const IconBase = ({ children, color, size, style, ...props }, { reactIconBase = {} }) => {
   const computedSize = size || reactIconBase.size || '1em'
   return (

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "prop-types": "*"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
See https://github.com/facebook/react/blob/master/CHANGELOG.md for reference.
Is the the package. I added it as peer dependency.
https://github.com/reactjs/prop-types