### PR TITLE
Use default export from 'prop-types' package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { default as React } from 'react'
-import { PropTypes } from 'prop-types'
+import PropTypes from 'prop-types'
 const IconBase = ({ children, color, size, style, ...props }, { reactIconBase = {} }) => {
   const computedSize = size || reactIconBase.size || '1em'
   return (


### PR DESCRIPTION
According to react/prop-types [README](https://github.com/reactjs/prop-types#importing), we should import prop-types using the following statement:
```js
import PropTypes from 'prop-types'; // ES6
```

For some reason, using named import crashes my app in production. Changing to default import just solved the issue magically. ¯\\\_(ツ)\_/¯