### PR TITLE
Allow explicitly setting width & height

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 import { default as React } from 'react'
 import PropTypes from 'prop-types'
-const IconBase = ({ children, color, size, style, ...props }, { reactIconBase = {} }) => {
+const IconBase = ({ children, color, size, style, width, height, ...props }, { reactIconBase = {} }) => {
   const computedSize = size || reactIconBase.size || '1em'
   return (
     <svg
       children={children}
       fill='currentColor'
       preserveAspectRatio='xMidYMid meet'
-      height={computedSize}
-      width={computedSize}
+      height={height || computedSize}
+      width={width || computedSize}
       {...reactIconBase}
       {...props}
       style={{
@@ -24,6 +24,14 @@ const IconBase = ({ children, color, size, style, ...props }, { reactIconBase = 
 IconBase.propTypes = {
   color: PropTypes.string,
   size: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  width: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
   ]),


### PR DESCRIPTION
Useful for non-square SVGs (e.g: a logo / logotype).