### PR TITLE
Use compatible version of prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^2.5.3",
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.2.1",
-    "prop-types": "15.5.8",
+    "prop-types": "^15.5.8",
     "standard": "^7.1.2",
     "validate-commit-msg": "^2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^2.5.3",
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.2.1",
-    "prop-types": "^15.5.8",
+    "prop-types": "*",
     "standard": "^7.1.2",
     "validate-commit-msg": "^2.6.1"
   },


### PR DESCRIPTION
To avoid npm warnings when project uses fresher version of prop-types. 