### PR TITLE
master(color): update color priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const IconBase = ({ children, color, size, style, width, height, ...props }, { reactIconBase = {} }) => {
+const IconBase = ({ children, color, size, style = {}, width, height, ...props }, { reactIconBase = {} }) => {
   const computedSize = size || reactIconBase.size || '1em'
+
+  const baseStyle = reactIconBase.style || {}
+  const styleProp = {
+    verticalAlign: 'middle',
+    ...baseStyle,
+    ...style
+  }
+
+  const computedColor = color || style.color || reactIconBase.color || baseStyle.color
+  if (computedColor) {
+    styleProp.color = computedColor
+  }
+
   return (
     <svg
       children={children}
@@ -12,12 +25,7 @@ const IconBase = ({ children, color, size, style, width, height, ...props }, { r
       width={width || computedSize}
       {...reactIconBase}
       {...props}
-      style={{
-        verticalAlign: 'middle',
-        color: color || reactIconBase.color,
-        ...(reactIconBase.style || {}),
-        ...style
-      }}
+      style={styleProp}
     />
   )
 }

--- a/test/helpers/pass-context.js
+++ b/test/helpers/pass-context.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class PassContext extends React.Component {
+  getChildContext () {
+    return {
+      reactIconBase: this.props.context
+    }
+  }
+
+  render () {
+    return React.Children.only(this.props.children)
+  }
+}
+
+PassContext.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+PassContext.childContextTypes = {
+  reactIconBase: PropTypes.object.isRequired
+}
+
+export default PassContext

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactTestRenderer from 'react-test-renderer'
 import expect from 'expect'
 import IconBase from '..'
+import PassContext from './helpers/pass-context'
 
 describe('IconBase', () => {
   let outer
@@ -24,6 +25,48 @@ describe('IconBase', () => {
   })
 
   it('has does not have a default color', () => {
-    expect(outer.props.style.color).toNotExist()
+    expect(Object.prototype.hasOwnProperty.call(outer.props.style), 'color').toBe(false)
+  })
+})
+
+describe('Colors priority', () => {
+  it('uses the reactIconBase.style.color first', () => {
+    const rendered = ReactTestRenderer.create((
+      <PassContext context={{ style: { color: 'red' } }}>
+        <IconBase />
+      </PassContext>
+    ))
+
+    expect(rendered.toJSON().props.style.color).toEqual('red')
+  })
+
+  it('uses the reactIconBase.color second', () => {
+    const rendered = ReactTestRenderer.create((
+      <PassContext context={{ style: { color: 'red' }, color: 'blue' }}>
+        <IconBase />
+      </PassContext>
+    ))
+
+    expect(rendered.toJSON().props.style.color).toEqual('blue')
+  })
+
+  it('uses style.color third', () => {
+    const rendered = ReactTestRenderer.create((
+      <PassContext context={{ style: { color: 'red' }, color: 'blue' }}>
+        <IconBase style={{ color: 'purple' }} />
+      </PassContext>
+    ))
+
+    expect(rendered.toJSON().props.style.color).toEqual('purple')
+  })
+
+  it('uses color fourth', () => {
+    const rendered = ReactTestRenderer.create((
+      <PassContext context={{ style: { color: 'red' }, color: 'blue' }}>
+        <IconBase style={{ color: 'purple' }} color='orange' />
+      </PassContext>
+    ))
+
+    expect(rendered.toJSON().props.style.color).toEqual('orange')
   })
 })


### PR DESCRIPTION
This updates the colors priority by, in order, using:
1. the `color` prop
2. the `style.color` prop
3. the `color` context prop
4. the `style.color` context prop

This also removes `color: undefined` from the generated style if no
color is specified.

Not sure you agree with this, I can change if needed.