### PR TITLE
Add verticalAlign option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Context can be overriden inline, like so:
 <Icon size={30} color='aliceblue' style={{ ... }} />
 ```
 
+A css `vertical-align` is added with `'middle'` by default. You can pass a `verticalAlign` prop to remove it using `'none'`:
+
+```js
+<Icon verticalAlign='none' />
+```
+
+Or change it using any other option:
+
+```js
+<Icon verticalAlign='top' />
+```
+
 ### Licence
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const IconBase = ({ children, color, size, style = {}, width, height, ...props }, { reactIconBase = {} }) => {
-  const computedSize = size || reactIconBase.size || '1em'
+const IconBase = (
+  { children, color, size, style = {}, width, height, verticalAlign = 'middle', ...props },
+  { reactIconBase = {} },
+) => {
+  const computedSize = size || reactIconBase.size || '1em';
 
-  const baseStyle = reactIconBase.style || {}
+  const baseStyle = reactIconBase.style || {};
   const styleProp = {
-    verticalAlign: 'middle',
     ...baseStyle,
-    ...style
-  }
+    ...style,
+  };
+  if (verticalAlign !== 'none') styleProp.verticalAlign = verticalAlign;
 
   const computedColor = color || style.color || reactIconBase.color || baseStyle.color
   if (computedColor) {


### PR DESCRIPTION
It allows `vertical-align` to be removed using 'none' or modified using any other option.

Not using the `verticalAlign` option injects `vertical-align: middle` so it's backwards compatible.